### PR TITLE
Enable setting exclude characters via environment variable

### DIFF
--- a/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
@@ -119,8 +119,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
@@ -113,8 +113,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
@@ -118,8 +118,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
@@ -112,8 +112,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -118,8 +118,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '`/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='`/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -112,8 +112,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
@@ -118,8 +118,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _CLONE appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\', PasswordLength=30)
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters, PasswordLength=30)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
@@ -112,8 +112,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\', PasswordLength=30)
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters, PasswordLength=30)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -119,8 +119,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else ':/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=':/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -113,8 +113,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else ':/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=':/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
@@ -118,8 +118,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\', PasswordLength=30)
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters, PasswordLength=30)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSSQLServerRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationSingleUser/lambda_function.py
@@ -112,8 +112,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\', PasswordLength=30)
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters, PasswordLength=30)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
@@ -119,8 +119,10 @@ def create_secret(service_client, arn, token):
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\:'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\:')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRedshiftRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRedshiftRotationSingleUser/lambda_function.py
@@ -113,8 +113,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\:'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\:')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRotationTemplate/lambda_function.py
+++ b/SecretsManagerRotationTemplate/lambda_function.py
@@ -94,8 +94,10 @@ def create_secret(service_client, arn, token):
         service_client.get_secret_value(SecretId=arn, VersionId=token, VersionStage="AWSPENDING")
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Get exclude characters from environment variable
+        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=passwd['RandomPassword'], VersionStages=['AWSPENDING'])


### PR DESCRIPTION
Partial solution to Issue #17

Allow customization of 'exclude characters' through an environment variable - `EXCLUDE_CHARACTERS`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
